### PR TITLE
Update: Elasticsearch revisited V 0.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,18 @@
-FROM million12/centos-supervisor
-MAINTAINER Przemyslaw Ozgo <linux@ozgo.info>
+FROM centos:centos7
+MAINTAINER Marcin Ryzycki marcin@m12.io, Przemyslaw Ozgo linux@ozgo.info
 
 RUN \
-yum update -y && \
-yum install -y tar java-1.7.0-openjdk && \
-yum clean all && \
+    yum update -y && \
+    yum install -y tar java-1.7.0-openjdk && \
+    yum clean all && \
+    # Install Elasticsearch
+    mkdir -p /opt/elasticsearch && \
+    cd /opt/elasticsearch && \
+    curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.3.2.tar.gz && \
+    tar zxvf elasticsearch-1.3.2.tar.gz -C /opt/elasticsearch --strip-components=1 && \
+    rm elasticsearch-1.3.2.tar.gz && \
+    /opt/elasticsearch/bin/plugin -i elasticsearch/marvel/latest && \
+    /opt/elasticsearch/bin/plugin -url http://download.elasticsearch.org/kibana/kibana/kibana-latest.zip -install elasticsearch/kibana3
 
-# Install Elasticsearch 
-
-mkdir -p /opt/elasticsearch && \
-cd /opt/elasticsearch && \
-curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.3.2.tar.gz && \
-tar zxvf elasticsearch-1.3.2.tar.gz -C /opt/elasticsearch --strip-components=1 && \
-rm elasticsearch-1.3.2.tar.gz && \
-/opt/elasticsearch/bin/plugin -i elasticsearch/marvel/latest && \
-/opt/elasticsearch/bin/plugin -url http://download.elasticsearch.org/kibana/kibana/kibana-latest.zip -install elasticsearch/kibana3
-
-ADD supervisord.conf /etc/supervisor.d/elasticsearch.conf
-
+CMD /opt/elasticsearch/bin/elasticsearch
 EXPOSE 9200

--- a/README.md
+++ b/README.md
@@ -1,22 +1,31 @@
 #Elasticsearch docker image 
-Based on million12/centos-supervisor docker image. 
+[Docker Image](https://registry.hub.docker.com/u/million12/elasticsearch/) with [Elasticsearch](http://www.elasticsearch.org/) server. 
 
 Plugins Installed:
 
-1. Kibana 3.1.0
+1. Kibana 
 2. Marver
 
 ###Run 
 `docker run -d --name elasticsearch -p 9200:9200 million12/elasticsearch`
 
-###Access Web Interface
->   htttp://elasticsearch_ip:9200/_plugin/marvel
+### Custom Config 
+User can use custom configuration file by adding `-v` option into run command (see example).  
+Default configuration directory: `/opt/elasticsearch/config/`
+  
+`docker run -d --name elasticsearch -p 9200:9200 -v /path/to/myconfig.file:/opt/elasticsearch/config/elasticsearch.yml million12/elasticsearch` 
 
+###Access Web Interface
+>   htttp://elasticsearch_ip:9200/_plugin/marvel  
 >   htttp://elasticsearch_ip:9200/_plugin/kibana3
+
+### SystemD .service file
+For easy deployment using systemd we provide an example of `.service` file. See `systemd` directory
 
 ## Author(s)
 
-* Przemyslaw Ozgo linux@ozgo.info
+Author: Marcin ryzy Ryzycki (<marcin@m12.io>)  
+Author: Przemyslaw Ozgo (<linux@ozgo.info>)
 
 ---
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,3 +1,0 @@
-[program:elasticsearch]
-command = /opt/elasticsearch/bin/elasticsearch
-autorestart = true

--- a/systemd/elasticsearch.service
+++ b/systemd/elasticsearch.service
@@ -1,13 +1,22 @@
 [Unit]
-Description=elasticsearch
+Description=Elasticsearch Server
+After=docker.service
+Requires=docker.service
 
 [Service]
-EnvironmentFile=/etc/environment
+TimeoutStartSec=0
+Type=oneshot
+RemainAfterExit=true
+ExecStartPre=-/usr/bin/docker kill elasticsearch
+ExecStartPre=-/usr/bin/docker rm -f elasticsearch
 ExecStartPre=/usr/bin/docker pull million12/elasticsearch
-ExecStart=/usr/bin/docker run --rm --name elasticsearch -p 9200:9200 -e HOST_IP=${COREOS_PUBLIC_IPV4} million12/elasticsearch
-ExecStartPost=/usr/bin/etcdctl set /elasticsearch/host ${COREOS_PUBLIC_IPV4}
-ExecStop=/usr/bin/docker kill elasticsearch
-ExecStopPost=/usr/bin/etcdctl rm /elasticsearch/host
+ExecStart=/usr/bin/docker run \
+-d \
+--name elasticsearch \
+-p 9200:9200 \
+million12/elasticsearch
+ExecStop=/usr/bin/docker stop elasticsearch
+Restart=allways
 
-[X-Fleet]
-X-Conflicts=elasticsearch.service
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Reorganised whole process.
- Moved to official CentOS 7 base image. (Stripped down to 460MB from 609MB) 
